### PR TITLE
Add Yii backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore PHP dependencies and runtime files
+/vendor/
+/backend/vendor/
+/backend/runtime/
+*.log
+*.cache
+.DS_Store
+composer.lock

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend Project
+
+This is a minimal Yii2 backend setup. To install dependencies run:
+
+```
+composer install
+```
+
+Then you can start a PHP server from the `web` directory:
+
+```
+php -S localhost:8080
+```

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "example/backend",
+    "description": "Yii2 backend project",
+    "type": "project",
+    "require": {
+        "php": ">=8.0.0",
+        "yiisoft/yii2": "~2.0.47"
+    },
+    "require-dev": {
+        "yiisoft/yii2-debug": "~2.1.0",
+        "yiisoft/yii2-gii": "~2.2.0"
+    },
+    "config": {
+        "process-timeout": 1800,
+        "sort-packages": true
+    }
+}

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -1,0 +1,25 @@
+<?php
+$params = [];
+
+return [
+    'id' => 'backend-app',
+    'basePath' => dirname(__DIR__),
+    'bootstrap' => ['log'],
+    'components' => [
+        'request' => [
+            'cookieValidationKey' => 'changeit',
+        ],
+        'cache' => [
+            'class' => yii\caching\FileCache::class,
+        ],
+        'log' => [
+            'targets' => [
+                [
+                    'class' => yii\log\FileTarget::class,
+                    'levels' => ['error', 'warning'],
+                ],
+            ],
+        ],
+    ],
+    'params' => $params,
+];

--- a/backend/controllers/SiteController.php
+++ b/backend/controllers/SiteController.php
@@ -1,0 +1,12 @@
+<?php
+namespace app\controllers;
+
+use yii\web\Controller;
+
+class SiteController extends Controller
+{
+    public function actionIndex()
+    {
+        return $this->render('index');
+    }
+}

--- a/backend/views/site/index.php
+++ b/backend/views/site/index.php
@@ -1,0 +1,4 @@
+<?php
+/** @var yii\web\View $this */
+?>
+<h1>Welcome to Yii Backend</h1>

--- a/backend/web/index.php
+++ b/backend/web/index.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
+
+$config = require __DIR__ . '/../config/web.php';
+
+(new yii\web\Application($config))->run();


### PR DESCRIPTION
## Summary
- add .gitignore ignoring vendor folders, runtime, and misc files
- create `backend` subdirectory with Yii2 skeleton
- include minimal composer.json, config, controller, view and web entry script
- add instructions in backend README

## Testing
- `php -l backend/web/index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f92ec7f788330b8d08d5b183571b7