### PR TITLE
Implement basic JWT RBAC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This project is a simple Yii2 based REST API backend. It uses MySQL for
 storage and JSON Web Tokens (JWT) for authentication. Example endpoints are
 defined in `SiteController` and demonstrate role based access control.
+
+## Database Migrations
+
+Run the following command from the `backend` directory to apply migrations:
+
+```bash
+./yii migrate
+```
+
+This will create the required tables such as the `user` table.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # ebal
+
+This project is a simple Yii2 based REST API backend. It uses MySQL for
+storage and JSON Web Tokens (JWT) for authentication. Example endpoints are
+defined in `SiteController` and demonstrate role based access control.

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,3 +11,11 @@ Then you can start a PHP server from the `web` directory:
 ```
 php -S localhost:8080
 ```
+
+### Running Migrations
+
+After installing dependencies, apply migrations with:
+
+```bash
+./yii migrate
+```

--- a/backend/components/Jwt.php
+++ b/backend/components/Jwt.php
@@ -1,0 +1,21 @@
+<?php
+namespace app\components;
+
+use Firebase\JWT\JWT as BaseJwt;
+use Firebase\JWT\Key;
+
+class Jwt
+{
+    public string $key;
+    public string $alg = 'HS256';
+
+    public function encode(array $payload): string
+    {
+        return BaseJwt::encode($payload, $this->key, $this->alg);
+    }
+
+    public function decode(string $token): array
+    {
+        return (array) BaseJwt::decode($token, new Key($this->key, $this->alg));
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -4,7 +4,8 @@
     "type": "project",
     "require": {
         "php": ">=8.0.0",
-        "yiisoft/yii2": "~2.0.47"
+        "yiisoft/yii2": "~2.0.47",
+        "firebase/php-jwt": "^6.9"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.1.0",
@@ -13,5 +14,10 @@
     "config": {
         "process-timeout": 1800,
         "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "app\\": ""
+        }
     }
 }

--- a/backend/config/console.php
+++ b/backend/config/console.php
@@ -1,0 +1,24 @@
+<?php
+return [
+    'id' => 'backend-console',
+    'basePath' => dirname(__DIR__),
+    'bootstrap' => ['log'],
+    'controllerNamespace' => 'app\commands',
+    'components' => [
+        'db' => require __DIR__ . '/db.php',
+        'authManager' => [
+            'class' => yii\rbac\DbManager::class,
+        ],
+        'cache' => [
+            'class' => yii\caching\FileCache::class,
+        ],
+        'log' => [
+            'targets' => [
+                [
+                    'class' => yii\log\FileTarget::class,
+                    'levels' => ['error', 'warning'],
+                ],
+            ],
+        ],
+    ],
+];

--- a/backend/config/db.php
+++ b/backend/config/db.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'class' => yii\db\Connection::class,
+    'dsn' => getenv('DB_DSN') ?: 'mysql:host=127.0.0.1;dbname=app',
+    'username' => getenv('DB_USER') ?: 'root',
+    'password' => getenv('DB_PASS') ?: '',
+    'charset' => 'utf8',
+];

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -8,10 +8,29 @@ return [
     'components' => [
         'request' => [
             'cookieValidationKey' => 'changeit',
+            'parsers' => [
+                'application/json' => yii\web\JsonParser::class,
+            ],
+        ],
+        'response' => [
+            'format' => yii\web\Response::FORMAT_JSON,
         ],
         'cache' => [
             'class' => yii\caching\FileCache::class,
         ],
+        'user' => [
+            'identityClass' => app\models\User::class,
+            'enableSession' => false,
+            'loginUrl' => null,
+        ],
+        'jwt' => [
+            'class' => app\components\Jwt::class,
+            'key' => getenv('JWT_KEY') ?: 'secret',
+        ],
+        'authManager' => [
+            'class' => yii\rbac\DbManager::class,
+        ],
+        'db' => require __DIR__ . '/db.php',
         'log' => [
             'targets' => [
                 [

--- a/backend/controllers/SiteController.php
+++ b/backend/controllers/SiteController.php
@@ -1,12 +1,68 @@
 <?php
 namespace app\controllers;
 
-use yii\web\Controller;
+use yii\rest\Controller;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
 
 class SiteController extends Controller
 {
-    public function actionIndex()
+    public function behaviors()
     {
-        return $this->render('index');
+        $behaviors = parent::behaviors();
+
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+            'except' => ['public', 'login'],
+        ];
+
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'only' => ['dashboard', 'admin'],
+            'rules' => [
+                [
+                    'actions' => ['dashboard'],
+                    'allow' => true,
+                    'roles' => ['@'],
+                ],
+                [
+                    'actions' => ['admin'],
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+
+        return $behaviors;
+    }
+
+    public function actionPublic()
+    {
+        return ['message' => 'Public endpoint'];
+    }
+
+    public function actionLogin()
+    {
+        $body = Yii::$app->request->bodyParams;
+        $user = \app\models\User::findOne(['username' => $body['username'] ?? null]);
+        if ($user && Yii::$app->security->validatePassword($body['password'] ?? '', $user->password_hash)) {
+            return ['token' => $user->generateJwt()];
+        }
+        Yii::$app->response->statusCode = 401;
+        return ['error' => 'Invalid credentials'];
+    }
+
+    public function actionDashboard()
+    {
+        return ['message' => 'Dashboard', 'user' => Yii::$app->user->identity->username];
+    }
+
+    public function actionAdmin()
+    {
+        return ['message' => 'Admin area'];
     }
 }

--- a/backend/migrations/m230101_000000_create_user_table.php
+++ b/backend/migrations/m230101_000000_create_user_table.php
@@ -1,0 +1,23 @@
+<?php
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%user}}`.
+ */
+class m230101_000000_create_user_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%user}}', [
+            'id' => $this->primaryKey(),
+            'username' => $this->string()->notNull()->unique(),
+            'password_hash' => $this->string()->notNull(),
+            'role' => $this->string()->notNull()->defaultValue('user'),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%user}}');
+    }
+}

--- a/backend/models/User.php
+++ b/backend/models/User.php
@@ -1,0 +1,49 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+use yii\web\IdentityInterface;
+use Yii;
+
+class User extends ActiveRecord implements IdentityInterface
+{
+    public static function tableName()
+    {
+        return '{{%user}}';
+    }
+
+    public static function findIdentity($id)
+    {
+        return static::findOne($id);
+    }
+
+    public static function findIdentityByAccessToken($token, $type = null)
+    {
+        $data = Yii::$app->jwt->decode($token);
+        return static::findOne($data['id'] ?? null);
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getAuthKey()
+    {
+        return null;
+    }
+
+    public function validateAuthKey($authKey)
+    {
+        return false;
+    }
+
+    public function generateJwt(): string
+    {
+        $payload = [
+            'id' => $this->id,
+            'role' => $this->role,
+        ];
+        return Yii::$app->jwt->encode($payload);
+    }
+}

--- a/backend/yii
+++ b/backend/yii
@@ -1,0 +1,10 @@
+#!/usr/bin/env php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/vendor/yiisoft/yii2/Yii.php';
+
+$config = require __DIR__ . '/config/console.php';
+
+$application = new yii\console\Application($config);
+$exitCode = $application->run();
+exit($exitCode);


### PR DESCRIPTION
## Summary
- create MySQL DB config
- add JWT helper component and User model
- configure backend for REST API with JWT authentication
- add mock endpoints in SiteController demonstrating RBAC
- update composer dependencies
- document the API in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa8006e04833083660610b6673137