### PR TITLE
Add membership and group management modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # ebal
 
-This project is a simple Yii2 based REST API backend. It uses MySQL for
-storage and JSON Web Tokens (JWT) for authentication. Example endpoints are
-defined in `SiteController` and demonstrate role based access control.
+"Ebal" stands for "Every Breath and Life" and is a tiny planning portal for our
+worship ministry.  It is a lightweight Yii2 powered REST API that keeps track of
+team members and the groups they serve in.  Think of it as a mini Planning
+Center tailor‑made for our church with room to grow to other congregations.
+
+The service relies on MySQL and secures requests using JSON Web Tokens (JWT).
+Admins can manage members, create groups like *guitarists* or *singers*, and
+assign people to any number of teams.  Whether it's rehearsals or Sunday
+service, ebal keeps everyone on the same page.
+
+API endpoints for these modules are documented in `openapi.yaml`.
 
 ## Database Migrations
 
@@ -12,4 +20,5 @@ Run the following command from the `backend` directory to apply migrations:
 ./yii migrate
 ```
 
-This will create the required tables such as the `user` table.
+This will create the required tables such as the `user`, `member`, and `group`
+tables as well as the join table for member assignments.

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -39,6 +39,28 @@ return [
                 ],
             ],
         ],
+        'urlManager' => [
+            'enablePrettyUrl' => true,
+            'enableStrictParsing' => true,
+            'showScriptName' => false,
+            'rules' => [
+                [
+                    'class' => yii\rest\UrlRule::class,
+                    'controller' => [
+                        'members' => 'member',
+                        'groups' => 'group',
+                    ],
+                    'extraPatterns' => [
+                        'POST {id}/members' => 'add-member',
+                        'DELETE {id}/members/<member_id>' => 'remove-member',
+                    ],
+                ],
+                'POST login' => 'site/login',
+                'GET public' => 'site/public',
+                'GET dashboard' => 'site/dashboard',
+                'GET admin' => 'site/admin',
+            ],
+        ],
     ],
     'params' => $params,
 ];

--- a/backend/controllers/GroupController.php
+++ b/backend/controllers/GroupController.php
@@ -1,0 +1,71 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+use yii\web\BadRequestHttpException;
+use app\models\MemberGroup;
+use app\models\Group;
+use app\models\Member;
+
+class GroupController extends ActiveController
+{
+    public $modelClass = \app\models\Group::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+
+    public function actionAddMember($id)
+    {
+        $memberId = Yii::$app->request->bodyParams['member_id'] ?? null;
+        if (!$memberId) {
+            throw new BadRequestHttpException('member_id required');
+        }
+        if (!Group::findOne($id) || !Member::findOne($memberId)) {
+            throw new BadRequestHttpException('Invalid group or member');
+        }
+        $link = MemberGroup::findOne(['group_id' => $id, 'member_id' => $memberId]);
+        if ($link) {
+            return $link; // already assigned
+        }
+        $link = new MemberGroup(['group_id' => $id, 'member_id' => $memberId]);
+        if ($link->save()) {
+            Yii::$app->response->statusCode = 201;
+            return $link;
+        }
+        Yii::$app->response->statusCode = 400;
+        return $link->errors;
+    }
+
+    public function actionRemoveMember($id, $member_id)
+    {
+        $link = MemberGroup::findOne(['group_id' => $id, 'member_id' => $member_id]);
+        if ($link) {
+            $link->delete();
+            Yii::$app->response->statusCode = 204;
+            return null;
+        }
+        Yii::$app->response->statusCode = 404;
+        return ['error' => 'Not found'];
+    }
+}

--- a/backend/controllers/MemberController.php
+++ b/backend/controllers/MemberController.php
@@ -1,0 +1,33 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+
+class MemberController extends ActiveController
+{
+    public $modelClass = \app\models\Member::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+}

--- a/backend/migrations/m230102_000001_create_member_table.php
+++ b/backend/migrations/m230102_000001_create_member_table.php
@@ -1,0 +1,20 @@
+<?php
+use yii\db\Migration;
+
+class m230102_000001_create_member_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%member}}', [
+            'id' => $this->primaryKey(),
+            'name' => $this->string()->notNull(),
+            'email' => $this->string()->unique(),
+            'phone' => $this->string(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%member}}');
+    }
+}

--- a/backend/migrations/m230102_000002_create_group_table.php
+++ b/backend/migrations/m230102_000002_create_group_table.php
@@ -1,0 +1,19 @@
+<?php
+use yii\db\Migration;
+
+class m230102_000002_create_group_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%group}}', [
+            'id' => $this->primaryKey(),
+            'name' => $this->string()->notNull()->unique(),
+            'description' => $this->text(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%group}}');
+    }
+}

--- a/backend/migrations/m230102_000003_create_member_group_table.php
+++ b/backend/migrations/m230102_000003_create_member_group_table.php
@@ -1,0 +1,23 @@
+<?php
+use yii\db\Migration;
+
+class m230102_000003_create_member_group_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%member_group}}', [
+            'member_id' => $this->integer()->notNull(),
+            'group_id' => $this->integer()->notNull(),
+        ]);
+        $this->addPrimaryKey('pk_member_group', '{{%member_group}}', ['member_id', 'group_id']);
+        $this->addForeignKey('fk_member_group_member', '{{%member_group}}', 'member_id', '{{%member}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_member_group_group', '{{%member_group}}', 'group_id', '{{%group}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_member_group_member', '{{%member_group}}');
+        $this->dropForeignKey('fk_member_group_group', '{{%member_group}}');
+        $this->dropTable('{{%member_group}}');
+    }
+}

--- a/backend/models/Group.php
+++ b/backend/models/Group.php
@@ -1,0 +1,28 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class Group extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%group}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['name'], 'string', 'max' => 255],
+            [['description'], 'string'],
+            [['name'], 'unique'],
+        ];
+    }
+
+    public function getMembers()
+    {
+        return $this->hasMany(Member::class, ['id' => 'member_id'])
+            ->viaTable('{{%member_group}}', ['group_id' => 'id']);
+    }
+}

--- a/backend/models/Member.php
+++ b/backend/models/Member.php
@@ -1,0 +1,27 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class Member extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%member}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['name', 'email', 'phone'], 'string', 'max' => 255],
+            ['email', 'email'],
+        ];
+    }
+
+    public function getGroups()
+    {
+        return $this->hasMany(Group::class, ['id' => 'group_id'])
+            ->viaTable('{{%member_group}}', ['member_id' => 'id']);
+    }
+}

--- a/backend/models/MemberGroup.php
+++ b/backend/models/MemberGroup.php
@@ -1,0 +1,17 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class MemberGroup extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%member_group}}';
+    }
+
+    public static function primaryKey()
+    {
+        return ['member_id', 'group_id'];
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,201 @@
+openapi: 3.0.3
+info:
+  title: Worship Team API
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/
+paths:
+  /members:
+    get:
+      summary: List members
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Member'
+    post:
+      summary: Create member
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Member'
+      responses:
+        '201':
+          description: Created
+  /members/{id}:
+    get:
+      summary: Get member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Member'
+    put:
+      summary: Update member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Member'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /groups:
+    get:
+      summary: List groups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
+    post:
+      summary: Create group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+      responses:
+        '201':
+          description: Created
+  /groups/{id}:
+    get:
+      summary: Get group
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+    put:
+      summary: Update group
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete group
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /groups/{id}/members:
+    post:
+      summary: Add member to group
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_id:
+                  type: integer
+      responses:
+        '201':
+          description: Added
+  /groups/{id}/members/{member_id}:
+    delete:
+      summary: Remove member from group
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: member_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Removed
+components:
+  schemas:
+    Member:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+    Group:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string


### PR DESCRIPTION
## Summary
- add models for Member, Group, and MemberGroup
- create migrations for new tables and assignments
- implement Member and Group controllers with admin-only access
- configure URL rules and add assignment endpoints
- document REST API in OpenAPI YAML
- mention new modules in README
- validate group member assignments and expand README details

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fade8310c8330bde204009b6073e4