### PR TITLE
Add lineup templates and lineups modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Admins can manage members, create groups like *guitarists* or *singers*, and
 assign people to any number of teams.  Whether it's rehearsals or Sunday
 service, ebal keeps everyone on the same page.
 
+Recent additions include lineup templates which define the desired number of
+people from each group, and service lineups that assign actual members for a
+particular worship service. Templates make it easy to prefill a lineup and then
+swap out members as needed.
+
 API endpoints for these modules are documented in `openapi.yaml`.
 
 ## Database Migrations

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -55,6 +55,28 @@ return [
                         'DELETE {id}/members/<member_id>' => 'remove-member',
                     ],
                 ],
+                [
+                    'class' => yii\rest\UrlRule::class,
+                    'controller' => [
+                        'lineup-templates' => 'lineup-template',
+                    ],
+                    'extraPatterns' => [
+                        'POST {id}/groups' => 'add-group',
+                        'PUT {id}/groups/<group_id>' => 'update-group',
+                        'DELETE {id}/groups/<group_id>' => 'remove-group',
+                    ],
+                ],
+                [
+                    'class' => yii\rest\UrlRule::class,
+                    'controller' => [
+                        'lineups' => 'lineup',
+                    ],
+                    'extraPatterns' => [
+                        'POST {id}/members' => 'add-member',
+                        'PUT {id}/members/<member_id>' => 'update-member',
+                        'DELETE {id}/members/<member_id>' => 'remove-member',
+                    ],
+                ],
                 'POST login' => 'site/login',
                 'GET public' => 'site/public',
                 'GET dashboard' => 'site/dashboard',

--- a/backend/controllers/LineupController.php
+++ b/backend/controllers/LineupController.php
@@ -1,0 +1,109 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+use yii\web\BadRequestHttpException;
+use app\models\LineupMember;
+use app\models\Lineup;
+use app\models\Member;
+use app\models\Group;
+
+class LineupController extends ActiveController
+{
+    public $modelClass = Lineup::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+
+    public function actionAddMember($id)
+    {
+        $memberId = Yii::$app->request->bodyParams['member_id'] ?? null;
+        $groupId = Yii::$app->request->bodyParams['group_id'] ?? null;
+        if (!$memberId || !$groupId) {
+            throw new BadRequestHttpException('member_id and group_id required');
+        }
+        if (!Lineup::findOne($id) || !Member::findOne($memberId) || !Group::findOne($groupId)) {
+            throw new BadRequestHttpException('Invalid lineup, member or group');
+        }
+        $model = LineupMember::findOne(['lineup_id' => $id, 'member_id' => $memberId]);
+        if ($model) {
+            Yii::$app->response->statusCode = 400;
+            return ['error' => 'Member already assigned'];
+        }
+        $model = new LineupMember(['lineup_id' => $id, 'member_id' => $memberId, 'group_id' => $groupId]);
+        if ($model->save()) {
+            Yii::$app->response->statusCode = 201;
+            return $model;
+        }
+        Yii::$app->response->statusCode = 400;
+        return $model->errors;
+    }
+
+    public function actionUpdateMember($id, $member_id)
+    {
+        $newMemberId = Yii::$app->request->bodyParams['member_id'] ?? $member_id;
+        $groupId = Yii::$app->request->bodyParams['group_id'] ?? null;
+        $model = LineupMember::findOne(['lineup_id' => $id, 'member_id' => $member_id]);
+        if (!$model) {
+            Yii::$app->response->statusCode = 404;
+            return ['error' => 'Not found'];
+        }
+        if ($newMemberId != $member_id) {
+            if (!Member::findOne($newMemberId)) {
+                throw new BadRequestHttpException('Invalid member_id');
+            }
+            $model->delete();
+            $model = new LineupMember(['lineup_id' => $id, 'member_id' => $newMemberId, 'group_id' => $groupId ?? $model->group_id]);
+            if ($model->save()) {
+                return $model;
+            }
+            Yii::$app->response->statusCode = 400;
+            return $model->errors;
+        }
+        if ($groupId !== null) {
+            if (!Group::findOne($groupId)) {
+                throw new BadRequestHttpException('Invalid group_id');
+            }
+            $model->group_id = $groupId;
+            if ($model->save()) {
+                return $model;
+            }
+            Yii::$app->response->statusCode = 400;
+            return $model->errors;
+        }
+        throw new BadRequestHttpException('Nothing to update');
+    }
+
+    public function actionRemoveMember($id, $member_id)
+    {
+        $model = LineupMember::findOne(['lineup_id' => $id, 'member_id' => $member_id]);
+        if ($model) {
+            $model->delete();
+            Yii::$app->response->statusCode = 204;
+            return null;
+        }
+        Yii::$app->response->statusCode = 404;
+        return ['error' => 'Not found'];
+    }
+}

--- a/backend/controllers/LineupTemplateController.php
+++ b/backend/controllers/LineupTemplateController.php
@@ -1,0 +1,92 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+use yii\web\BadRequestHttpException;
+use app\models\LineupTemplateGroup;
+use app\models\Group;
+use app\models\LineupTemplate;
+
+class LineupTemplateController extends ActiveController
+{
+    public $modelClass = LineupTemplate::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+
+    public function actionAddGroup($id)
+    {
+        $groupId = Yii::$app->request->bodyParams['group_id'] ?? null;
+        $count = Yii::$app->request->bodyParams['count'] ?? 1;
+        if (!$groupId || !Group::findOne($groupId)) {
+            throw new BadRequestHttpException('Invalid group_id');
+        }
+        if (!LineupTemplate::findOne($id)) {
+            throw new BadRequestHttpException('Invalid template');
+        }
+        $model = LineupTemplateGroup::findOne(['template_id' => $id, 'group_id' => $groupId]);
+        if ($model) {
+            $model->count = $count;
+        } else {
+            $model = new LineupTemplateGroup(['template_id' => $id, 'group_id' => $groupId, 'count' => $count]);
+        }
+        if ($model->save()) {
+            Yii::$app->response->statusCode = 201;
+            return $model;
+        }
+        Yii::$app->response->statusCode = 400;
+        return $model->errors;
+    }
+
+    public function actionUpdateGroup($id, $group_id)
+    {
+        $count = Yii::$app->request->bodyParams['count'] ?? null;
+        $model = LineupTemplateGroup::findOne(['template_id' => $id, 'group_id' => $group_id]);
+        if (!$model) {
+            Yii::$app->response->statusCode = 404;
+            return ['error' => 'Not found'];
+        }
+        if ($count !== null) {
+            $model->count = $count;
+            if ($model->save()) {
+                return $model;
+            }
+            Yii::$app->response->statusCode = 400;
+            return $model->errors;
+        }
+        throw new BadRequestHttpException('count required');
+    }
+
+    public function actionRemoveGroup($id, $group_id)
+    {
+        $model = LineupTemplateGroup::findOne(['template_id' => $id, 'group_id' => $group_id]);
+        if ($model) {
+            $model->delete();
+            Yii::$app->response->statusCode = 204;
+            return null;
+        }
+        Yii::$app->response->statusCode = 404;
+        return ['error' => 'Not found'];
+    }
+}

--- a/backend/migrations/m230103_000004_create_lineup_template_table.php
+++ b/backend/migrations/m230103_000004_create_lineup_template_table.php
@@ -1,0 +1,18 @@
+<?php
+use yii\db\Migration;
+
+class m230103_000004_create_lineup_template_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%lineup_template}}', [
+            'id' => $this->primaryKey(),
+            'name' => $this->string()->notNull()->unique(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%lineup_template}}');
+    }
+}

--- a/backend/migrations/m230103_000005_create_lineup_template_group_table.php
+++ b/backend/migrations/m230103_000005_create_lineup_template_group_table.php
@@ -1,0 +1,24 @@
+<?php
+use yii\db\Migration;
+
+class m230103_000005_create_lineup_template_group_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%lineup_template_group}}', [
+            'template_id' => $this->integer()->notNull(),
+            'group_id' => $this->integer()->notNull(),
+            'count' => $this->integer()->notNull()->defaultValue(1),
+        ]);
+        $this->addPrimaryKey('pk_lineup_template_group', '{{%lineup_template_group}}', ['template_id','group_id']);
+        $this->addForeignKey('fk_lt_group_template', '{{%lineup_template_group}}', 'template_id', '{{%lineup_template}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_lt_group_group', '{{%lineup_template_group}}', 'group_id', '{{%group}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_lt_group_group', '{{%lineup_template_group}}');
+        $this->dropForeignKey('fk_lt_group_template', '{{%lineup_template_group}}');
+        $this->dropTable('{{%lineup_template_group}}');
+    }
+}

--- a/backend/migrations/m230103_000006_create_lineup_table.php
+++ b/backend/migrations/m230103_000006_create_lineup_table.php
@@ -1,0 +1,21 @@
+<?php
+use yii\db\Migration;
+
+class m230103_000006_create_lineup_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%lineup}}', [
+            'id' => $this->primaryKey(),
+            'service_datetime' => $this->dateTime()->notNull(),
+            'template_id' => $this->integer(),
+        ]);
+        $this->addForeignKey('fk_lineup_template', '{{%lineup}}', 'template_id', '{{%lineup_template}}', 'id', 'SET NULL', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_lineup_template', '{{%lineup}}');
+        $this->dropTable('{{%lineup}}');
+    }
+}

--- a/backend/migrations/m230103_000007_create_lineup_member_table.php
+++ b/backend/migrations/m230103_000007_create_lineup_member_table.php
@@ -1,0 +1,26 @@
+<?php
+use yii\db\Migration;
+
+class m230103_000007_create_lineup_member_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%lineup_member}}', [
+            'lineup_id' => $this->integer()->notNull(),
+            'member_id' => $this->integer()->notNull(),
+            'group_id' => $this->integer()->notNull(),
+        ]);
+        $this->addPrimaryKey('pk_lineup_member', '{{%lineup_member}}', ['lineup_id','member_id']);
+        $this->addForeignKey('fk_lineup_member_lineup', '{{%lineup_member}}', 'lineup_id', '{{%lineup}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_lineup_member_member', '{{%lineup_member}}', 'member_id', '{{%member}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_lineup_member_group', '{{%lineup_member}}', 'group_id', '{{%group}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_lineup_member_group', '{{%lineup_member}}');
+        $this->dropForeignKey('fk_lineup_member_member', '{{%lineup_member}}');
+        $this->dropForeignKey('fk_lineup_member_lineup', '{{%lineup_member}}');
+        $this->dropTable('{{%lineup_member}}');
+    }
+}

--- a/backend/models/Lineup.php
+++ b/backend/models/Lineup.php
@@ -1,0 +1,36 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class Lineup extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%lineup}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['service_datetime'], 'required'],
+            [['service_datetime'], 'safe'],
+            [['template_id'], 'integer'],
+        ];
+    }
+
+    public function getTemplate()
+    {
+        return $this->hasOne(LineupTemplate::class, ['id' => 'template_id']);
+    }
+
+    public function getLineupMembers()
+    {
+        return $this->hasMany(LineupMember::class, ['lineup_id' => 'id']);
+    }
+
+    public function getMembers()
+    {
+        return $this->hasMany(Member::class, ['id' => 'member_id'])->via('lineupMembers');
+    }
+}

--- a/backend/models/LineupMember.php
+++ b/backend/models/LineupMember.php
@@ -1,0 +1,40 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class LineupMember extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%lineup_member}}';
+    }
+
+    public static function primaryKey()
+    {
+        return ['lineup_id', 'member_id'];
+    }
+
+    public function rules()
+    {
+        return [
+            [['lineup_id', 'member_id', 'group_id'], 'required'],
+            [['lineup_id', 'member_id', 'group_id'], 'integer'],
+        ];
+    }
+
+    public function getLineup()
+    {
+        return $this->hasOne(Lineup::class, ['id' => 'lineup_id']);
+    }
+
+    public function getMember()
+    {
+        return $this->hasOne(Member::class, ['id' => 'member_id']);
+    }
+
+    public function getGroup()
+    {
+        return $this->hasOne(Group::class, ['id' => 'group_id']);
+    }
+}

--- a/backend/models/LineupTemplate.php
+++ b/backend/models/LineupTemplate.php
@@ -1,0 +1,31 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class LineupTemplate extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%lineup_template}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['name'], 'string', 'max' => 255],
+            [['name'], 'unique'],
+        ];
+    }
+
+    public function getTemplateGroups()
+    {
+        return $this->hasMany(LineupTemplateGroup::class, ['template_id' => 'id']);
+    }
+
+    public function getGroups()
+    {
+        return $this->hasMany(Group::class, ['id' => 'group_id'])->via('templateGroups');
+    }
+}

--- a/backend/models/LineupTemplateGroup.php
+++ b/backend/models/LineupTemplateGroup.php
@@ -1,0 +1,35 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class LineupTemplateGroup extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%lineup_template_group}}';
+    }
+
+    public static function primaryKey()
+    {
+        return ['template_id', 'group_id'];
+    }
+
+    public function rules()
+    {
+        return [
+            [['template_id', 'group_id', 'count'], 'required'],
+            [['template_id', 'group_id', 'count'], 'integer'],
+        ];
+    }
+
+    public function getTemplate()
+    {
+        return $this->hasOne(LineupTemplate::class, ['id' => 'template_id']);
+    }
+
+    public function getGroup()
+    {
+        return $this->hasOne(Group::class, ['id' => 'group_id']);
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -177,6 +177,272 @@ paths:
       responses:
         '204':
           description: Removed
+  /lineup-templates:
+    get:
+      summary: List lineup templates
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LineupTemplate'
+    post:
+      summary: Create lineup template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LineupTemplate'
+      responses:
+        '201':
+          description: Created
+  /lineup-templates/{id}:
+    get:
+      summary: Get lineup template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineupTemplate'
+    put:
+      summary: Update lineup template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LineupTemplate'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete lineup template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /lineup-templates/{id}/groups:
+    post:
+      summary: Add group to template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                group_id:
+                  type: integer
+                count:
+                  type: integer
+      responses:
+        '201':
+          description: Added
+  /lineup-templates/{id}/groups/{group_id}:
+    put:
+      summary: Update group on template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: group_id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                count:
+                  type: integer
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Remove group from template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: group_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Removed
+  /lineups:
+    get:
+      summary: List lineups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Lineup'
+    post:
+      summary: Create lineup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lineup'
+      responses:
+        '201':
+          description: Created
+  /lineups/{id}:
+    get:
+      summary: Get lineup
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lineup'
+    put:
+      summary: Update lineup
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lineup'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete lineup
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /lineups/{id}/members:
+    post:
+      summary: Add member to lineup
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_id:
+                  type: integer
+                group_id:
+                  type: integer
+      responses:
+        '201':
+          description: Added
+  /lineups/{id}/members/{member_id}:
+    put:
+      summary: Replace or update member
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: member_id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_id:
+                  type: integer
+                group_id:
+                  type: integer
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Remove member from lineup
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: member_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Removed
 components:
   schemas:
     Member:
@@ -199,3 +465,20 @@ components:
           type: string
         description:
           type: string
+    LineupTemplate:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Lineup:
+      type: object
+      properties:
+        id:
+          type: integer
+        service_datetime:
+          type: string
+          format: date-time
+        template_id:
+          type: integer


### PR DESCRIPTION
## Summary
- manage lineup templates and lineups
- document new API endpoints

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb299d344833093b28a6c18f84062