### PR TITLE
Add song management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ people from each group, and service lineups that assign actual members for a
 particular worship service. Templates make it easy to prefill a lineup and then
 swap out members as needed.
 
+This update introduces song management. Song categories organize songs, and each
+song records its original key and author. Song lists tie songs to a worship
+service lineup in a particular order.
+
 API endpoints for these modules are documented in `openapi.yaml`.
 
 ## Database Migrations

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -58,6 +58,24 @@ return [
                 [
                     'class' => yii\rest\UrlRule::class,
                     'controller' => [
+                        'song-categories' => 'song-category',
+                        'songs' => 'song',
+                    ],
+                ],
+                [
+                    'class' => yii\rest\UrlRule::class,
+                    'controller' => [
+                        'song-lists' => 'song-list',
+                    ],
+                    'extraPatterns' => [
+                        'POST {id}/songs' => 'add-song',
+                        'PUT {id}/songs/<song_id>' => 'update-song',
+                        'DELETE {id}/songs/<song_id>' => 'remove-song',
+                    ],
+                ],
+                [
+                    'class' => yii\rest\UrlRule::class,
+                    'controller' => [
                         'lineup-templates' => 'lineup-template',
                     ],
                     'extraPatterns' => [

--- a/backend/controllers/SongCategoryController.php
+++ b/backend/controllers/SongCategoryController.php
@@ -1,0 +1,33 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+
+class SongCategoryController extends ActiveController
+{
+    public $modelClass = \app\models\SongCategory::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+}

--- a/backend/controllers/SongController.php
+++ b/backend/controllers/SongController.php
@@ -1,0 +1,33 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+
+class SongController extends ActiveController
+{
+    public $modelClass = \app\models\Song::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+}

--- a/backend/controllers/SongListController.php
+++ b/backend/controllers/SongListController.php
@@ -1,0 +1,128 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\AccessControl;
+use yii\filters\auth\HttpBearerAuth;
+use Yii;
+use yii\web\BadRequestHttpException;
+use app\models\SongListSong;
+use app\models\SongList;
+use app\models\Song;
+
+class SongListController extends ActiveController
+{
+    public $modelClass = SongList::class;
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+        $behaviors['access'] = [
+            'class' => AccessControl::class,
+            'rules' => [
+                [
+                    'allow' => true,
+                    'roles' => ['@'],
+                    'matchCallback' => function () {
+                        return Yii::$app->user->identity->role === 'admin';
+                    },
+                ],
+            ],
+        ];
+        return $behaviors;
+    }
+
+    public function actionAddSong($id)
+    {
+        $songId = Yii::$app->request->bodyParams['song_id'] ?? null;
+        $order = Yii::$app->request->bodyParams['order'] ?? null;
+        $actualKey = Yii::$app->request->bodyParams['actual_key'] ?? null;
+        $version = Yii::$app->request->bodyParams['version'] ?? null;
+        $notes = Yii::$app->request->bodyParams['notes'] ?? null;
+        if (!$songId || $order === null) {
+            throw new BadRequestHttpException('song_id and order required');
+        }
+        if (!SongList::findOne($id) || !Song::findOne($songId)) {
+            throw new BadRequestHttpException('Invalid song list or song');
+        }
+        if (SongListSong::findOne(['song_list_id' => $id, 'song_id' => $songId])) {
+            Yii::$app->response->statusCode = 400;
+            return ['error' => 'Song already added'];
+        }
+        $model = new SongListSong([
+            'song_list_id' => $id,
+            'song_id' => $songId,
+            'song_order' => $order,
+            'actual_key' => $actualKey,
+            'version' => $version,
+            'notes' => $notes,
+        ]);
+        if ($model->save()) {
+            Yii::$app->response->statusCode = 201;
+            return $model;
+        }
+        Yii::$app->response->statusCode = 400;
+        return $model->errors;
+    }
+
+    public function actionUpdateSong($id, $song_id)
+    {
+        $newSongId = Yii::$app->request->bodyParams['song_id'] ?? $song_id;
+        $order = Yii::$app->request->bodyParams['order'] ?? null;
+        $actualKey = Yii::$app->request->bodyParams['actual_key'] ?? null;
+        $version = Yii::$app->request->bodyParams['version'] ?? null;
+        $notes = Yii::$app->request->bodyParams['notes'] ?? null;
+        $model = SongListSong::findOne(['song_list_id' => $id, 'song_id' => $song_id]);
+        if (!$model) {
+            Yii::$app->response->statusCode = 404;
+            return ['error' => 'Not found'];
+        }
+        if ($newSongId != $song_id) {
+            if (!Song::findOne($newSongId)) {
+                throw new BadRequestHttpException('Invalid song_id');
+            }
+            $model->delete();
+            $model = new SongListSong([
+                'song_list_id' => $id,
+                'song_id' => $newSongId,
+                'song_order' => $order ?? $model->song_order,
+                'actual_key' => $actualKey ?? $model->actual_key,
+                'version' => $version ?? $model->version,
+                'notes' => $notes ?? $model->notes,
+            ]);
+            if ($model->save()) {
+                return $model;
+            }
+            Yii::$app->response->statusCode = 400;
+            return $model->errors;
+        }
+        $changed = false;
+        if ($order !== null) { $model->song_order = $order; $changed = true; }
+        if ($actualKey !== null) { $model->actual_key = $actualKey; $changed = true; }
+        if ($version !== null) { $model->version = $version; $changed = true; }
+        if ($notes !== null) { $model->notes = $notes; $changed = true; }
+        if ($changed && $model->save()) {
+            return $model;
+        }
+        if ($changed) {
+            Yii::$app->response->statusCode = 400;
+            return $model->errors;
+        }
+        throw new BadRequestHttpException('Nothing to update');
+    }
+
+    public function actionRemoveSong($id, $song_id)
+    {
+        $model = SongListSong::findOne(['song_list_id' => $id, 'song_id' => $song_id]);
+        if ($model) {
+            $model->delete();
+            Yii::$app->response->statusCode = 204;
+            return null;
+        }
+        Yii::$app->response->statusCode = 404;
+        return ['error' => 'Not found'];
+    }
+}

--- a/backend/migrations/m230104_000008_create_song_category_table.php
+++ b/backend/migrations/m230104_000008_create_song_category_table.php
@@ -1,0 +1,19 @@
+<?php
+use yii\db\Migration;
+
+class m230104_000008_create_song_category_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%song_category}}', [
+            'id' => $this->primaryKey(),
+            'name' => $this->string()->notNull()->unique(),
+            'description' => $this->text(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%song_category}}');
+    }
+}

--- a/backend/migrations/m230104_000009_create_song_table.php
+++ b/backend/migrations/m230104_000009_create_song_table.php
@@ -1,0 +1,23 @@
+<?php
+use yii\db\Migration;
+
+class m230104_000009_create_song_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%song}}', [
+            'id' => $this->primaryKey(),
+            'category_id' => $this->integer(),
+            'title' => $this->string()->notNull(),
+            'original_key' => $this->string(),
+            'original_author' => $this->string(),
+        ]);
+        $this->addForeignKey('fk_song_category', '{{%song}}', 'category_id', '{{%song_category}}', 'id', 'SET NULL', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_song_category', '{{%song}}');
+        $this->dropTable('{{%song}}');
+    }
+}

--- a/backend/migrations/m230104_000010_create_song_list_table.php
+++ b/backend/migrations/m230104_000010_create_song_list_table.php
@@ -1,0 +1,21 @@
+<?php
+use yii\db\Migration;
+
+class m230104_000010_create_song_list_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%song_list}}', [
+            'id' => $this->primaryKey(),
+            'lineup_id' => $this->integer()->notNull(),
+            'author' => $this->string()->notNull(),
+        ]);
+        $this->addForeignKey('fk_song_list_lineup', '{{%song_list}}', 'lineup_id', '{{%lineup}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_song_list_lineup', '{{%song_list}}');
+        $this->dropTable('{{%song_list}}');
+    }
+}

--- a/backend/migrations/m230104_000011_create_song_list_song_table.php
+++ b/backend/migrations/m230104_000011_create_song_list_song_table.php
@@ -1,0 +1,27 @@
+<?php
+use yii\db\Migration;
+
+class m230104_000011_create_song_list_song_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%song_list_song}}', [
+            'song_list_id' => $this->integer()->notNull(),
+            'song_id' => $this->integer()->notNull(),
+            'song_order' => $this->integer()->notNull(),
+            'actual_key' => $this->string(),
+            'version' => $this->string(),
+            'notes' => $this->text(),
+        ]);
+        $this->addPrimaryKey('pk_song_list_song', '{{%song_list_song}}', ['song_list_id','song_id']);
+        $this->addForeignKey('fk_song_list_song_list', '{{%song_list_song}}', 'song_list_id', '{{%song_list}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_song_list_song_song', '{{%song_list_song}}', 'song_id', '{{%song}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_song_list_song_song', '{{%song_list_song}}');
+        $this->dropForeignKey('fk_song_list_song_list', '{{%song_list_song}}');
+        $this->dropTable('{{%song_list_song}}');
+    }
+}

--- a/backend/models/Song.php
+++ b/backend/models/Song.php
@@ -1,0 +1,26 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class Song extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%song}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['title'], 'required'],
+            [['title', 'original_key', 'original_author'], 'string', 'max' => 255],
+            [['category_id'], 'integer'],
+        ];
+    }
+
+    public function getCategory()
+    {
+        return $this->hasOne(SongCategory::class, ['id' => 'category_id']);
+    }
+}

--- a/backend/models/SongCategory.php
+++ b/backend/models/SongCategory.php
@@ -1,0 +1,27 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class SongCategory extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%song_category}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['name'], 'required'],
+            [['name'], 'string', 'max' => 255],
+            [['description'], 'string'],
+            [['name'], 'unique'],
+        ];
+    }
+
+    public function getSongs()
+    {
+        return $this->hasMany(Song::class, ['category_id' => 'id']);
+    }
+}

--- a/backend/models/SongList.php
+++ b/backend/models/SongList.php
@@ -1,0 +1,36 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class SongList extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%song_list}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['lineup_id', 'author'], 'required'],
+            [['lineup_id'], 'integer'],
+            [['author'], 'string', 'max' => 255],
+        ];
+    }
+
+    public function getLineup()
+    {
+        return $this->hasOne(Lineup::class, ['id' => 'lineup_id']);
+    }
+
+    public function getSongListSongs()
+    {
+        return $this->hasMany(SongListSong::class, ['song_list_id' => 'id']);
+    }
+
+    public function getSongs()
+    {
+        return $this->hasMany(Song::class, ['id' => 'song_id'])->via('songListSongs');
+    }
+}

--- a/backend/models/SongListSong.php
+++ b/backend/models/SongListSong.php
@@ -1,0 +1,37 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class SongListSong extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%song_list_song}}';
+    }
+
+    public static function primaryKey()
+    {
+        return ['song_list_id', 'song_id'];
+    }
+
+    public function rules()
+    {
+        return [
+            [['song_list_id', 'song_id', 'song_order'], 'required'],
+            [['song_list_id', 'song_id', 'song_order'], 'integer'],
+            [['actual_key', 'version'], 'string', 'max' => 255],
+            [['notes'], 'string'],
+        ];
+    }
+
+    public function getSongList()
+    {
+        return $this->hasOne(SongList::class, ['id' => 'song_list_id']);
+    }
+
+    public function getSong()
+    {
+        return $this->hasOne(Song::class, ['id' => 'song_id']);
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -443,6 +443,286 @@ paths:
       responses:
         '204':
           description: Removed
+  /song-categories:
+    get:
+      summary: List song categories
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SongCategory'
+    post:
+      summary: Create song category
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SongCategory'
+      responses:
+        '201':
+          description: Created
+  /song-categories/{id}:
+    get:
+      summary: Get song category
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SongCategory'
+    put:
+      summary: Update song category
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SongCategory'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete song category
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /songs:
+    get:
+      summary: List songs
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Song'
+    post:
+      summary: Create song
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Song'
+      responses:
+        '201':
+          description: Created
+  /songs/{id}:
+    get:
+      summary: Get song
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Song'
+    put:
+      summary: Update song
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Song'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete song
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /song-lists:
+    get:
+      summary: List song lists
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SongList'
+    post:
+      summary: Create song list
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SongList'
+      responses:
+        '201':
+          description: Created
+  /song-lists/{id}:
+    get:
+      summary: Get song list
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SongList'
+    put:
+      summary: Update song list
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SongList'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete song list
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /song-lists/{id}/songs:
+    post:
+      summary: Add song to list
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                song_id:
+                  type: integer
+                order:
+                  type: integer
+                actual_key:
+                  type: string
+                version:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '201':
+          description: Added
+  /song-lists/{id}/songs/{song_id}:
+    put:
+      summary: Replace or update song
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: song_id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                song_id:
+                  type: integer
+                order:
+                  type: integer
+                actual_key:
+                  type: string
+                version:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Remove song from list
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: song_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Removed
 components:
   schemas:
     Member:
@@ -482,3 +762,34 @@ components:
           format: date-time
         template_id:
           type: integer
+    SongCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+    Song:
+      type: object
+      properties:
+        id:
+          type: integer
+        category_id:
+          type: integer
+        title:
+          type: string
+        original_key:
+          type: string
+        original_author:
+          type: string
+    SongList:
+      type: object
+      properties:
+        id:
+          type: integer
+        lineup_id:
+          type: integer
+        author:
+          type: string


### PR DESCRIPTION
## Summary
- add SongCategory, Song, SongList, and SongListSong models
- create migrations for the new tables
- implement CRUD controllers for songs and categories
- manage songs within a song list
- document new endpoints and schemas in `openapi.yaml`
- wire routes for the new controllers
- update README with description of song management

## Testing
- ❌ `php -l backend/migrations/m230104_000008_create_song_category_table.php` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5e1979483308c6ee533b1882868