### PR TITLE
Add lightweight React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.cache
 .DS_Store
 composer.lock
+
+# Ignore compiled frontend JS
+/frontend/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ composer.lock
 
 # Ignore compiled frontend JS
 /frontend/dist/
+/frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ tables as well as the join table for member assignments.
 
 ## Frontend
 
-A lightweight React frontend lives in the `frontend` directory.  It is now a tiny
-Node project managed with **yarn**.  Install the dependencies and start the dev
-server with live reload using:
+A lightweight React frontend lives in the `frontend` directory.  It is a small
+Node project managed with **yarn** and built with **Vite**.  Install the
+dependencies and start the dev server with live reload using:
 
 ```bash
 cd frontend
@@ -44,5 +44,4 @@ yarn install
 yarn dev
 ```
 
-The TypeScript sources are compiled to `dist/` (ignored by git) and served by
-`lite-server`.  Run `yarn build` to generate the files once for production.
+Run `yarn build` to create a production bundle under `dist/`.

--- a/README.md
+++ b/README.md
@@ -34,4 +34,15 @@ tables as well as the join table for member assignments.
 
 ## Frontend
 
-A lightweight React frontend lives in the `frontend` directory. It uses TypeScript but still relies on CDN scripts for React, React Router and Bootstrap, so there are no npm dependencies. The compiled files under `frontend/dist` are not version controlled, so run `tsc` inside the `frontend` folder to generate them and then open `frontend/index.html`.
+A lightweight React frontend lives in the `frontend` directory.  It is now a tiny
+Node project managed with **yarn**.  Install the dependencies and start the dev
+server with live reload using:
+
+```bash
+cd frontend
+yarn install
+yarn dev
+```
+
+The TypeScript sources are compiled to `dist/` (ignored by git) and served by
+`lite-server`.  Run `yarn build` to generate the files once for production.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Run the following command from the `backend` directory to apply migrations:
 
 This will create the required tables such as the `user`, `member`, and `group`
 tables as well as the join table for member assignments.
+
+## Frontend
+
+A lightweight React frontend lives in the `frontend` directory. It uses TypeScript but still relies on CDN scripts for React, React Router and Bootstrap, so there are no npm dependencies. The compiled files under `frontend/dist` are not version controlled, so run `tsc` inside the `frontend` folder to generate them and then open `frontend/index.html`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,15 +1,19 @@
 # Ebal Frontend
 
-This folder contains a tiny React application written in TypeScript.  It relies on CDN versions of React, React Router and Bootstrap so there are no npm dependencies.
+This folder contains a tiny React application written in TypeScript.  It is now
+a small Node project managed with **yarn** and served using `lite-server` for
+automatic reloads.
 
-Source files live under `src/` and are compiled to plain JavaScript in `dist/` using the TypeScript compiler:
+Install dependencies and start the dev server from this directory:
 
 ```bash
-cd frontend
-tsc
+yarn install
+yarn dev
 ```
 
-Open `index.html` after running `tsc` (or use the precompiled files in `dist`).  The app provides three pages:
+TypeScript sources live under `src/` and compile to `dist/`.  Open `index.html`
+after running `yarn build` or let the dev server compile on the fly.  The app
+provides three pages:
 
 * **Home** – basic information and a link to the login form.
 * **Login** – posts credentials to the backend `/login` endpoint and stores the returned JWT.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,18 @@
+# Ebal Frontend
+
+This folder contains a tiny React application written in TypeScript.  It relies on CDN versions of React, React Router and Bootstrap so there are no npm dependencies.
+
+Source files live under `src/` and are compiled to plain JavaScript in `dist/` using the TypeScript compiler:
+
+```bash
+cd frontend
+tsc
+```
+
+Open `index.html` after running `tsc` (or use the precompiled files in `dist`).  The app provides three pages:
+
+* **Home** – basic information and a link to the login form.
+* **Login** – posts credentials to the backend `/login` endpoint and stores the returned JWT.
+* **Dashboard** – shows a message from the backend when authenticated.
+
+The UI automatically switches between light and dark Bootstrap themes based on your operating system preferences.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,8 @@
 # Ebal Frontend
 
-This folder contains a tiny React application written in TypeScript.  It is now
-a small Node project managed with **yarn** and served using `lite-server` for
-automatic reloads.
+This folder contains a small React application written in TypeScript.  It is a
+Node project managed with **yarn** and uses **Vite** for automatic reloads and
+bundling.
 
 Install dependencies and start the dev server from this directory:
 
@@ -11,9 +11,9 @@ yarn install
 yarn dev
 ```
 
-TypeScript sources live under `src/` and compile to `dist/`.  Open `index.html`
-after running `yarn build` or let the dev server compile on the fly.  The app
-provides three pages:
+TypeScript sources live under `src/` and are bundled into `dist/` when running
+`yarn build`.  During development Vite serves them directly.  The app provides
+three pages:
 
 * **Home** – basic information and a link to the login form.
 * **Login** – posts credentials to the backend `/login` endpoint and stores the returned JWT.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,8 @@
   <div id="root"></div>
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
+  <!-- use jsDelivr for the router to avoid CORS issues -->
+  <script src="https://cdn.jsdelivr.net/npm/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-NfMVR9MbW/R8+6KPBOqnpOY30XU5KCF4Rq+DQyY+5pCq5t94VrIiSRBkqm2F6S+N" crossorigin="anonymous"></script>
   <script type="module" src="./dist/App.js"></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ebal Portal</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ENjdO4Dr2bkBIFxQpeoYcg5YQiOrQbBkiGoM9lrEiZ1E6Vw6Q5V7iXkkKrKrVX5F" crossorigin="anonymous">
+  <style>
+    body {
+      padding-top: 4rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-NfMVR9MbW/R8+6KPBOqnpOY30XU5KCF4Rq+DQyY+5pCq5t94VrIiSRBkqm2F6S+N" crossorigin="anonymous"></script>
+  <script type="module" src="./dist/App.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ebal Portal</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ENjdO4Dr2bkBIFxQpeoYcg5YQiOrQbBkiGoM9lrEiZ1E6Vw6Q5V7iXkkKrKrVX5F" crossorigin="anonymous">
   <style>
     body {
       padding-top: 4rem;
@@ -13,11 +12,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <!-- use jsDelivr for the router to avoid CORS issues -->
-  <script src="https://cdn.jsdelivr.net/npm/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-NfMVR9MbW/R8+6KPBOqnpOY30XU5KCF4Rq+DQyY+5pCq5t94VrIiSRBkqm2F6S+N" crossorigin="anonymous"></script>
-  <script type="module" src="./dist/App.js"></script>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,12 +3,19 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "tsc",
-    "dev": "concurrently \"tsc -w\" \"lite-server\""
+    "dev": "vite",
+    "build": "vite build",
+    "check": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "bootstrap": "^5.3.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
-    "concurrently": "^8.0.1",
-    "lite-server": "^2.6.1",
-    "typescript": "^5.4.2"
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.0.7"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ebal-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "dev": "concurrently \"tsc -w\" \"lite-server\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1",
+    "lite-server": "^2.6.1",
+    "typescript": "^5.4.2"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,28 @@
+declare const React: any;
+declare const ReactDOM: any;
+declare const ReactRouterDOM: any;
+
+import useTheme from './useTheme';
+import Home from './Home';
+import Login from './Login';
+import Dashboard from './Dashboard';
+
+const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
+
+export default function App() {
+  useTheme();
+  const [token, setToken] = React.useState(localStorage.getItem('token') || '');
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login setToken={setToken} />} />
+        <Route path="/dashboard" element={<Dashboard token={token} />} />
+        <Route path="*" element={<Navigate to="/" />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,10 @@ declare const React: any;
 declare const ReactDOM: any;
 declare const ReactRouterDOM: any;
 
-import useTheme from './useTheme';
-import Home from './Home';
-import Login from './Login';
-import Dashboard from './Dashboard';
+import useTheme from './useTheme.js';
+import Home from './Home.js';
+import Login from './Login.js';
+import Dashboard from './Dashboard.js';
 
 const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,17 +1,13 @@
-declare const React: any;
-declare const ReactDOM: any;
-declare const ReactRouterDOM: any;
-
-import useTheme from './useTheme.js';
-import Home from './Home.js';
-import Login from './Login.js';
-import Dashboard from './Dashboard.js';
-
-const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
+import { useState } from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import useTheme from './useTheme';
+import Home from './Home';
+import Login from './Login';
+import Dashboard from './Dashboard';
 
 export default function App() {
   useTheme();
-  const [token, setToken] = React.useState(localStorage.getItem('token') || '');
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
 
   return (
     <BrowserRouter>
@@ -24,5 +20,3 @@ export default function App() {
     </BrowserRouter>
   );
 }
-
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,0 +1,32 @@
+declare const React: any;
+declare const ReactRouterDOM: any;
+
+const { Navigate } = ReactRouterDOM;
+
+interface DashboardProps {
+  token: string;
+}
+
+export default function Dashboard({ token }: DashboardProps) {
+  const [message, setMessage] = React.useState('');
+  const [user, setUser] = React.useState('');
+
+  React.useEffect(() => {
+    if (!token) return;
+    fetch('/dashboard', { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(res => res.json())
+      .then(data => {
+        setMessage(data.message);
+        setUser(data.user);
+      });
+  }, [token]);
+
+  if (!token) return <Navigate to="/login" />;
+
+  return (
+    <div className="container text-center">
+      <h2 className="mb-3">{message}</h2>
+      <p>Hello {user}</p>
+    </div>
+  );
+}

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,17 +1,15 @@
-declare const React: any;
-declare const ReactRouterDOM: any;
-
-const { Navigate } = ReactRouterDOM;
+import { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
 
 interface DashboardProps {
   token: string;
 }
 
 export default function Dashboard({ token }: DashboardProps) {
-  const [message, setMessage] = React.useState('');
-  const [user, setUser] = React.useState('');
+  const [message, setMessage] = useState('');
+  const [user, setUser] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!token) return;
     fetch('/dashboard', { headers: { 'Authorization': 'Bearer ' + token } })
       .then(res => res.json())

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,7 +1,4 @@
-declare const React: any;
-declare const ReactRouterDOM: any;
-
-const { Link } = ReactRouterDOM;
+import { Link } from 'react-router-dom';
 
 export default function Home() {
   return (

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,0 +1,14 @@
+declare const React: any;
+declare const ReactRouterDOM: any;
+
+const { Link } = ReactRouterDOM;
+
+export default function Home() {
+  return (
+    <div className="container text-center">
+      <h1 className="mb-3">Welcome to Ebal</h1>
+      <p className="mb-4">Every Breath and Life portal</p>
+      <Link className="btn btn-primary" to="/login">Login</Link>
+    </div>
+  );
+}

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,16 +1,14 @@
-declare const React: any;
-declare const ReactRouterDOM: any;
-
-const { useNavigate } = ReactRouterDOM;
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface LoginProps {
   setToken: (token: string) => void;
 }
 
 export default function Login({ setToken }: LoginProps) {
-  const [username, setUsername] = React.useState('');
-  const [password, setPassword] = React.useState('');
-  const [error, setError] = React.useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e: Event) => {

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,0 +1,52 @@
+declare const React: any;
+declare const ReactRouterDOM: any;
+
+const { useNavigate } = ReactRouterDOM;
+
+interface LoginProps {
+  setToken: (token: string) => void;
+}
+
+export default function Login({ setToken }: LoginProps) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) throw new Error('Invalid credentials');
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      setToken(data.token);
+      navigate('/dashboard');
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="container" style={{ maxWidth: '400px' }}>
+      <h2 className="mb-3">Login</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Username</label>
+          <input className="form-control" value={username} onChange={e => setUsername((e.target as HTMLInputElement).value)} />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input type="password" className="form-control" value={password} onChange={e => setPassword((e.target as HTMLInputElement).value)} />
+        </div>
+        <button type="submit" className="btn btn-primary">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,3 +1,0 @@
-declare const React: any;
-declare const ReactDOM: any;
-declare const ReactRouterDOM: any;

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare const React: any;
+declare const ReactDOM: any;
+declare const ReactRouterDOM: any;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,8 @@
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <App />
+);

--- a/frontend/src/useTheme.ts
+++ b/frontend/src/useTheme.ts
@@ -1,0 +1,12 @@
+declare const React: any;
+
+export default function useTheme(): void {
+  React.useEffect(() => {
+    const match = window.matchMedia('(prefers-color-scheme: dark)');
+    const apply = () =>
+      document.documentElement.setAttribute('data-bs-theme', match.matches ? 'dark' : 'light');
+    apply();
+    match.addEventListener('change', apply);
+    return () => match.removeEventListener('change', apply);
+  }, []);
+}

--- a/frontend/src/useTheme.ts
+++ b/frontend/src/useTheme.ts
@@ -1,7 +1,7 @@
-declare const React: any;
+import { useEffect } from 'react';
 
 export default function useTheme(): void {
-  React.useEffect(() => {
+  useEffect(() => {
     const match = window.matchMedia('(prefers-color-scheme: dark)');
     const apply = () =>
       document.documentElement.setAttribute('data-bs-theme', match.matches ? 'dark' : 'light');

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
-    "module": "ES2015",
-    "jsx": "react",
+    "target": "ES2017",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
     "strict": false,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "jsx": "react",
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add minimal React app in `frontend` that uses Bootstrap and CDN scripts
- document how to use the new UI
- mention frontend in root README
- ignore generated frontend dist files

## Testing
- `npx tsc -p frontend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_683fb915bf7c83309c80e1f00789e93f