### PR TITLE
Fix Codecov upload for PHP tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,6 +23,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
+          coverage: xdebug
       - name: Install dependencies
         run: composer self-update && composer install && composer dump-autoload
         working-directory: backend


### PR DESCRIPTION
## Summary
- install Xdebug in CI so phpunit can generate coverage

## Testing
- `yarn run check`

------
https://chatgpt.com/codex/tasks/task_e_68486a51bcd48330be1ed83f0e0a6f66