### PR TITLE
Enable editing member group assignments

### DIFF
--- a/backend/models/Member.php
+++ b/backend/models/Member.php
@@ -49,7 +49,10 @@ class Member extends ActiveRecord
             MemberGroup::deleteAll(['member_id' => $this->id]);
             foreach ($this->group_ids as $gid) {
                 $mg = new MemberGroup(['member_id' => $this->id, 'group_id' => $gid]);
-                $mg->save();
+                if (!$mg->save()) {
+                    // Log error or handle the failure
+                    Yii::error('Failed to save member group: ' . json_encode($mg->errors));
+                }
             }
         }
     }

--- a/backend/models/Member.php
+++ b/backend/models/Member.php
@@ -45,7 +45,7 @@ class Member extends ActiveRecord
     {
         parent::afterSave($insert, $changedAttributes);
 
-        if ($this->group_ids !== null) {
+        if (!empty($this->group_ids)) {
             MemberGroup::deleteAll(['member_id' => $this->id]);
             foreach ($this->group_ids as $gid) {
                 $mg = new MemberGroup(['member_id' => $this->id, 'group_id' => $gid]);

--- a/backend/models/Member.php
+++ b/backend/models/Member.php
@@ -3,8 +3,14 @@ namespace app\models;
 
 use yii\db\ActiveRecord;
 
+use app\models\MemberGroup;
+
 class Member extends ActiveRecord
 {
+    /**
+     * @var int[] IDs of groups the member belongs to
+     */
+    public array $group_ids = [];
     public static function tableName()
     {
         return '{{%member}}';
@@ -16,7 +22,36 @@ class Member extends ActiveRecord
             [['name'], 'required'],
             [['name', 'email', 'phone'], 'string', 'max' => 255],
             ['email', 'email'],
+            ['group_ids', 'each', 'rule' => ['integer']],
         ];
+    }
+
+    public function fields()
+    {
+        $fields = parent::fields();
+        $fields['group_ids'] = function (self $model) {
+            return array_map(fn($g) => $g->id, $model->groups);
+        };
+        return $fields;
+    }
+
+    public function afterFind()
+    {
+        parent::afterFind();
+        $this->group_ids = array_map(fn($g) => $g->id, $this->groups);
+    }
+
+    public function afterSave($insert, $changedAttributes)
+    {
+        parent::afterSave($insert, $changedAttributes);
+
+        if ($this->group_ids !== null) {
+            MemberGroup::deleteAll(['member_id' => $this->id]);
+            foreach ($this->group_ids as $gid) {
+                $mg = new MemberGroup(['member_id' => $this->id, 'group_id' => $gid]);
+                $mg->save();
+            }
+        }
     }
 
     public function getGroups()

--- a/backend/tests/unit/MemberTest.php
+++ b/backend/tests/unit/MemberTest.php
@@ -4,25 +4,10 @@ namespace tests\unit {
 }
 
 namespace app\models {
-    class MemberGroup {
-        public static array $deleted = [];
-        public static array $saved = [];
-        public int $member_id;
-        public int $group_id;
-        public function __construct(array $config = []) {
-            $this->member_id = $config['member_id'] ?? 0;
-            $this->group_id = $config['group_id'] ?? 0;
-        }
-        public static function deleteAll($condition) {
-            self::$deleted[] = $condition;
-        }
-        public function save() {
-            self::$saved[] = ['member_id' => $this->member_id, 'group_id' => $this->group_id];
-            return true;
-        }
-    }
-    class Group {
+    /** Simple stub used by the unit test to mimic a group model */
+    class DummyGroup {
         public int $id;
+
         public function __construct(int $id) { $this->id = $id; }
     }
 }
@@ -72,7 +57,7 @@ namespace tests\unit {
         public function testAfterFindPopulatesGroupIds(): void
         {
             $member = new Member();
-            $member->populateRelation('groups', [new \app\models\Group(1), new \app\models\Group(2)]);
+            $member->populateRelation('groups', [new \app\models\DummyGroup(1), new \app\models\DummyGroup(2)]);
             $member->afterFind();
             $this->assertSame([1,2], $member->group_ids);
         }

--- a/backend/tests/unit/MemberTest.php
+++ b/backend/tests/unit/MemberTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace tests\unit {
+    require_once __DIR__ . '/bootstrap.php';
+}
+
+namespace app\models {
+    class MemberGroup {
+        public static array $deleted = [];
+        public static array $saved = [];
+        public int $member_id;
+        public int $group_id;
+        public function __construct(array $config = []) {
+            $this->member_id = $config['member_id'] ?? 0;
+            $this->group_id = $config['group_id'] ?? 0;
+        }
+        public static function deleteAll($condition) {
+            self::$deleted[] = $condition;
+        }
+        public function save() {
+            self::$saved[] = ['member_id' => $this->member_id, 'group_id' => $this->group_id];
+            return true;
+        }
+    }
+    class Group {
+        public int $id;
+        public function __construct(int $id) { $this->id = $id; }
+    }
+}
+
+namespace tests\unit {
+    use app\models\Member;
+    use PHPUnit\Framework\TestCase;
+    use Yii;
+
+    class MemberTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            $mockDbConnection = new class {
+                public function getTableSchema($name, $refresh = false) {
+                    $tableSchema = new class {
+                        public $fullName;
+                        public $columns = [];
+                        public $primaryKey;
+
+                        public function getColumnNames() { return array_keys($this->columns); }
+                        public function getColumn($name) { return $this->columns[$name] ?? null; }
+                    };
+                    $tableSchema->fullName = $name;
+                    $tableSchema->columns = [ 'id' => (object)['name'=>'id'] ];
+                    $tableSchema->primaryKey = ['id'];
+                    return $tableSchema;
+                }
+                public function getSchema() {
+                    return new class($this) {
+                        private $db; public function __construct($db){$this->db=$db;}
+                        public function quoteTableName($n){return '`'.$n.'`';}
+                        public function quoteColumnName($n){return '`'.$n.'`';}
+                        public function getTableSchema($n,$r=false){return $this->db->getTableSchema($n,$r);} };
+                }
+                public function createCommand($sql=null,$params=[]){ return new class { public function execute(){return 0;} public function queryAll(){return [];} public function queryOne(){return false;} public function bindValues($v){return $this;} public function getRawSql(){return "";} }; }
+                public $driverName = 'mysql';
+                public $charset = 'utf8mb4';
+            };
+
+            Yii::$app = new class($mockDbConnection) {
+                private $db; public function __construct($db){$this->db=$db;}
+                public function getDb(){return $this->db;}
+                public function get($id,$throw=true){ if($id==='db') return $this->db; return null; }
+            };
+        }
+        public function testAfterFindPopulatesGroupIds(): void
+        {
+            $member = new Member();
+            $member->populateRelation('groups', [new \app\models\Group(1), new \app\models\Group(2)]);
+            $member->afterFind();
+            $this->assertSame([1,2], $member->group_ids);
+        }
+
+        // afterSave relies on database interaction which is beyond the scope of this unit test
+    }
+}

--- a/frontend/src/catalogs/Members.tsx
+++ b/frontend/src/catalogs/Members.tsx
@@ -31,7 +31,7 @@ export default function Members({ token }: { token: string }) {
       .then(setGroups);
   };
 
-  useEffect(load, []);
+  useEffect(load, [token, headers]);
 
   const submit = async () => {
     setError("");

--- a/frontend/src/catalogs/Members.tsx
+++ b/frontend/src/catalogs/Members.tsx
@@ -6,11 +6,18 @@ interface Member {
   name: string;
   email?: string;
   phone?: string;
+  group_ids?: number[];
+}
+
+interface Group {
+  id: number;
+  name: string;
 }
 
 export default function Members({ token }: { token: string }) {
   const [members, setMembers] = useState<Member[]>([]);
-  const [form, setForm] = useState<Omit<Member, 'id'>>({ name: '', email: '', phone: '' });
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [form, setForm] = useState<Omit<Member, 'id'> & { group_ids: number[] }>({ name: '', email: '', phone: '', group_ids: [] });
   const [editing, setEditing] = useState<number | null>(null);
   const [error, setError] = useState('');
   const headers = { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' };
@@ -19,6 +26,9 @@ export default function Members({ token }: { token: string }) {
     fetch('/api/members', { headers })
       .then(res => res.json())
       .then(setMembers);
+    fetch('/api/groups', { headers })
+      .then(res => res.json())
+      .then(setGroups);
   };
 
   useEffect(load, []);
@@ -36,7 +46,7 @@ export default function Members({ token }: { token: string }) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.message || "Request failed");
       }
-      setForm({ name: "", email: "", phone: "" });
+      setForm({ name: "", email: "", phone: "", group_ids: [] });
       setEditing(null);
       load();
     } catch (err) {
@@ -44,9 +54,30 @@ export default function Members({ token }: { token: string }) {
     }
   };
 
-  const edit = (m: Member) => { setForm({ name: m.name, email: m.email || "", phone: m.phone || "" }); setEditing(m.id); };
-  const cancel = () => { setEditing(null); setForm({ name: "", email: "", phone: "" }); setError(""); };
+  const edit = (m: Member) => {
+    setForm({
+      name: m.name,
+      email: m.email || '',
+      phone: m.phone || '',
+      group_ids: m.group_ids || []
+    });
+    setEditing(m.id);
+  };
+  const cancel = () => {
+    setEditing(null);
+    setForm({ name: '', email: '', phone: '', group_ids: [] });
+    setError('');
+  };
   const remove = async (id: number) => { await fetch(`/api/members/${id}`, { method: "DELETE", headers }); load(); };
+
+  const toggleGroup = (id: number) => {
+    setForm(f => ({
+      ...f,
+      group_ids: f.group_ids.includes(id)
+        ? f.group_ids.filter(g => g !== id)
+        : [...f.group_ids, id]
+    }));
+  };
   if (!token) return <Navigate to="/login" />;
 
   return (
@@ -61,6 +92,14 @@ export default function Members({ token }: { token: string }) {
           onChange={e => setForm({ ...form, email: (e.target as HTMLInputElement).value })} />
         <input className="form-control" placeholder="Phone" value={form.phone}
           onChange={e => setForm({ ...form, phone: (e.target as HTMLInputElement).value })} />
+        {groups.map(g => (
+          <div className="form-check" key={g.id}>
+            <input className="form-check-input" type="checkbox" id={'g'+g.id}
+              checked={form.group_ids.includes(g.id)}
+              onChange={() => toggleGroup(g.id)} />
+            <label className="form-check-label" htmlFor={'g'+g.id}>{g.name}</label>
+          </div>
+        ))}
         <div className="mt-2">
           <button className="btn btn-primary" onClick={submit}>{editing ? 'Update' : 'Add'}</button>
           {editing && <button className="btn btn-secondary ms-2" onClick={cancel}>Cancel</button>}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -736,6 +736,10 @@ components:
           type: string
         phone:
           type: string
+        group_ids:
+          type: array
+          items:
+            type: integer
     Group:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- expose group IDs on members in API
- persist group assignments when saving a member
- allow selecting groups when creating or editing a member in the frontend

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6849ca17fc2483308fab8cea41b00f8b