### PR TITLE
Add deploy job after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           REMOTE_APP_DIR: ${{ secrets.APP_DIRECTORY }}
           REMOTE_PROD_SERVER_NAME: ${{ secrets.PROD_SERVER_NAME }}
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} <<'DEPLOY'
+          ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "REMOTE_APP_DIR='$REMOTE_APP_DIR' REMOTE_PROD_SERVER_NAME='$REMOTE_PROD_SERVER_NAME' bash -s" <<'DEPLOY'
             set -e
             set -x # Enable command tracing
 


### PR DESCRIPTION
## Summary
- update build workflow to deploy to the server after backend and frontend jobs complete

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543ea3d8948330b4ce5f9bed7766f2